### PR TITLE
Core 564 fix duplicates in asset details page

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -89,66 +89,15 @@ module.exports = {
   // Check out SignalSettingsItem type in the Signals context folder to learn more
   signalSettings: {
     lastUpdated: new Date().toDateString(),
+    version: 0.1,
     signals: [
-      {
-        id: 'sample_quantitative_signal',
-        title: 'Sample Quantitative Signal',
-        description:
-          'Qualitative signal helps you make better investment decisions',
-        origin:
-          'https://62c5a9c8134fa108c2591da2.mockapi.io/api/protocol/v1/sample-signals/$assetId',
-        isCustom: false,
-        signals: [],
-        type: 1,
-        listView: {
-          id: 'listView',
-          value: true,
-          name: 'List View'
-        },
-        detailView: {
-          id: 'detailsView',
-          value: true,
-          name: 'Details View'
-        },
-        urlParams: {
-          assetIds: [],
-          publisherIds: [],
-          userAddresses: []
-        }
-      },
-      {
-        id: 'sample_qualitative_signal',
-        title: 'Sample Qualitative Signal',
-        description:
-          'Qualitative signal helps you make better investment decisions',
-        origin:
-          'https://62c5a9c8134fa108c2591da2.mockapi.io/api/protocol/v1/sample-signals/id?assetId=$assetId',
-        isCustom: false,
-        signals: [],
-        type: 1,
-        listView: {
-          id: 'listView',
-          value: true,
-          name: 'List View'
-        },
-        detailView: {
-          id: 'detailsView',
-          value: true,
-          name: 'Details View'
-        },
-        urlParams: {
-          assetIds: [],
-          publisherIds: [],
-          userAddresses: []
-        }
-      },
       {
         id: 'default_utu_signal',
         title: 'UTU Ocean Ranking Signal',
         description:
           'UTU Ocean signal helps you make better data market decisions',
         origin:
-          'https://stage-api.ututrust.com/core-api/ocean/ranking?assetId=$assetId&userAccount=$userAccount',
+          'https://stage-api.ututrust.com/core-api/ranking?assetId=$assetId&userAccount=$userAccount',
         isCustom: false,
         signals: [],
         type: 1,
@@ -174,7 +123,7 @@ module.exports = {
         description:
           'UTU Ocean signal helps you make better data market decisions',
         origin:
-          'https://stage-api.ututrust.com/core-api/ocean/interactionSummary?assetId=$assetId&userAccount=$userAccount',
+          'https://stage-api.ututrust.com/core-api/interactionSummary?assetId=$assetId&userAccount=$userAccount',
         isCustom: false,
         signals: [],
         type: 1,

--- a/app.config.js
+++ b/app.config.js
@@ -89,8 +89,60 @@ module.exports = {
   // Check out SignalSettingsItem type in the Signals context folder to learn more
   signalSettings: {
     lastUpdated: new Date().toDateString(),
-    version: 0.1,
+    version: 0.11,
     signals: [
+      // {
+      //   id: 'sample_quantitative_signal',
+      //   title: 'Sample Quantitative Signal',
+      //   description:
+      //       'Qualitative signal helps you make better investment decisions',
+      //   origin:
+      //       'https://62c5a9c8134fa108c2591da2.mockapi.io/api/protocol/v1/sample-signals/$assetId',
+      //   isCustom: false,
+      //   signals: [],
+      //   type: 1,
+      //   listView: {
+      //     id: 'listView',
+      //     value: true,
+      //     name: 'List View'
+      //   },
+      //   detailView: {
+      //     id: 'detailsView',
+      //     value: true,
+      //     name: 'Details View'
+      //   },
+      //   urlParams: {
+      //     assetIds: [],
+      //     publisherIds: [],
+      //     userAddresses: []
+      //   }
+      // },
+      // {
+      //   id: 'sample_qualitative_signal',
+      //   title: 'Sample Qualitative Signal',
+      //   description:
+      //       'Qualitative signal helps you make better investment decisions',
+      //   origin:
+      //       'https://62c5a9c8134fa108c2591da2.mockapi.io/api/protocol/v1/sample-signals/id?assetId=$assetId',
+      //   isCustom: false,
+      //   signals: [],
+      //   type: 1,
+      //   listView: {
+      //     id: 'listView',
+      //     value: true,
+      //     name: 'List View'
+      //   },
+      //   detailView: {
+      //     id: 'detailsView',
+      //     value: true,
+      //     name: 'Details View'
+      //   },
+      //   urlParams: {
+      //     assetIds: [],
+      //     publisherIds: [],
+      //     userAddresses: []
+      //   }
+      // },
       {
         id: 'default_utu_signal',
         title: 'UTU Ocean Ranking Signal',

--- a/src/@context/Signals/_types.ts
+++ b/src/@context/Signals/_types.ts
@@ -128,6 +128,7 @@ export interface SignalSettingsItem {
    */
   signals: SignalOriginItem[]
   enabled: boolean
+  version: number
 }
 
 export interface SignalParams {

--- a/src/@context/UserPreferences.tsx
+++ b/src/@context/UserPreferences.tsx
@@ -87,9 +87,18 @@ function UserPreferencesProvider({
     localStorage?.infiniteApproval || false
   )
   // Initialize signal settings
-  const [signalSettings, setSignalSettings] = useState<SignalSettingsItem>(
-    localStorage?.signalSettings || appConfig.signalSettings
-  )
+  let initSignalSettings: SignalSettingsItem = appConfig.signalSettings
+  if (localStorage?.signalSettings) {
+    if (localStorage.signalSettings && localStorage.signalSettings.version) {
+      if (
+        localStorage.signalSettings.version === appConfig.signalSettings.version
+      ) {
+        initSignalSettings = localStorage.signalSettings
+      }
+    }
+  }
+  const [signalSettings, setSignalSettings] =
+    useState<SignalSettingsItem>(initSignalSettings)
 
   // Write values to localStorage on change
   useEffect(() => {

--- a/src/@hooks/useSignals/_util.ts
+++ b/src/@hooks/useSignals/_util.ts
@@ -52,7 +52,7 @@ export function getSignalUrls(signalOriginItem: SignalOriginItem) {
 export async function fetchSignals(url: string): Promise<any[]> {
   if (url.length === 0) throw Error('empty url')
   try {
-    return await fetchData(url, { timeout: 4000 })
+    return await fetchData(url, { timeout: 10000 })
   } catch (error) {
     console.log(error)
     throw Error('Something went wrong with the signal fetch - ' + url)

--- a/src/components/@shared/atoms/AssetSignals/index.tsx
+++ b/src/components/@shared/atoms/AssetSignals/index.tsx
@@ -40,9 +40,9 @@ export default function AssetSignals({
     signalItems.forEach((item, index) => {
       if (item.signals.length > 1) {
         itemsList.push(
-          item.signals.map((sig) => {
+          item.signals.map((sig, index) => {
             return (
-              <li key={sig.id + item.title}>
+              <li key={sig.id + item.title + index}>
                 {sig ? (
                   <div className={styles.assetListTitle}>
                     <div className={styles.assetListTitleName}>
@@ -66,7 +66,7 @@ export default function AssetSignals({
       if (item.signals.length === 1) {
         itemsList.push(
           item.title ? (
-            <li key={index}>
+            <li key={item.id + item.title + index}>
               {item.signals ? (
                 <div className={styles.assetListTitle}>
                   <div className={styles.assetListTitleName}>
@@ -100,7 +100,7 @@ export default function AssetSignals({
           item.signals.map((sig) => {
             // Return @SignalsItem
             return (
-              <li key={index}>
+              <li key={sig.id + item.title + index}>
                 {item.signals.length > 0 ? (
                   <div className={styles.assetListTitle}>
                     <div className={styles.assetListTitleName}>

--- a/src/components/Asset/AssetActions/index.tsx
+++ b/src/components/Asset/AssetActions/index.tsx
@@ -58,7 +58,7 @@ export default function AssetActions({
   } = useSignalContext()
   const filterAssetSignals = () => {
     return signals
-      .filter((signal) => signal.type === 1)
+      .filter((signal) => true)
       .filter((signal) => signal.detailView.value)
   }
 


### PR DESCRIPTION
#### What does this PR do?
-- Fix duplicate signals by adding unique keys to the list of signal items in the asset details page
-- Comment out sample signals for use when testing etc
-- Increase the version number to make the signal settings reset

#### Description of Tasks to be completed?
As a user, I want to see UTU signals for on the ocean assets when  I visit the ocean market and have them render quickly without preventing me from seeing the asset cards

#### How should this be manually tested?


In the project directory, you can run:
```
$ npm install

$ npm start
```
##### Any background context you want to provide?
None

#### What are the relevant Jira Stories?
[#CORE-564](https://utu.atlassian.net/jira/software/projects/CORE/boards/3/backlog?selectedIssue=CORE-564)

#### Screenshots 
![image](https://user-images.githubusercontent.com/31648893/204818981-f1737fc5-d9cb-474b-9eac-6bce1cd83b75.png)
